### PR TITLE
add platforms, traversers and turntables

### DIFF
--- a/historical/historical.json
+++ b/historical/historical.json
@@ -266,7 +266,7 @@
             "construction",
             "rgba(242, 242, 235, 1)",
             "railway",
-            "rgba(224, 224, 224, 1)",
+            "rgba(214, 214, 214, 1)",
             "college",
             "rgba(226, 214, 205, 1)",
             "school",
@@ -1053,6 +1053,63 @@
       "paint": {
         "fill-color": "rgba(220, 215, 215, 1)",
         "fill-outline-color": "rgba(195, 188, 188, 1)"
+      }
+    },
+    {
+      "id": "transport_traverser",
+      "type": "fill",
+      "source": "osm",
+      "source-layer": "transport_areas",
+      "minzoom": 14,
+      "maxzoom": 24,
+      "filter": ["==", ["get", "type"], "traverser"],
+      "layout": {"visibility": "visible"},
+      "paint": {
+        "fill-color": "rgba(189, 141, 125, 0.15)",
+        "fill-opacity": 1,
+        "fill-outline-color": "rgba(208, 200, 200, 1)"
+      }
+    },
+    {
+      "id": "transport_turntable",
+      "type": "fill",
+      "source": "osm",
+      "source-layer": "transport_areas",
+      "minzoom": 14,
+      "filter": ["==", ["get", "type"], "turntable"],
+      "layout": {"visibility": "visible"},
+      "paint": {
+        "fill-color": "rgba(189, 141, 125, 0.15)",
+        "fill-opacity": 1,
+        "fill-outline-color": "rgba(208, 200, 200, 1)"
+      }
+    },
+    {
+      "id": "transport_passenger_platform",
+      "type": "fill",
+      "source": "osm",
+      "source-layer": "transport_areas",
+      "minzoom": 14,
+      "filter": ["==", ["get", "type"], "platform"],
+      "layout": {"visibility": "visible"},
+      "paint": {
+        "fill-color": "rgba(117, 101, 101, 0.15)",
+        "fill-opacity": 1,
+        "fill-outline-color": "rgba(208, 200, 200, 1)"
+      }
+    },
+    {
+      "id": "transport_freight_platform",
+      "type": "fill",
+      "source": "osm",
+      "source-layer": "transport_areas",
+      "minzoom": 14,
+      "filter": ["==", ["get", "type"], "loading_ramp"],
+      "layout": {"visibility": "visible"},
+      "paint": {
+        "fill-color": "rgba(117, 101, 101, 0.15)",
+        "fill-opacity": 1,
+        "fill-outline-color": "rgba(208, 200, 200, 1)"
       }
     },
     {

--- a/railway/railway.json
+++ b/railway/railway.json
@@ -1006,6 +1006,46 @@
       }
     },
     {
+      "id": "transport_passenger_platform",
+      "type": "fill",
+      "source": "osm",
+      "source-layer": "transport_areas",
+      "minzoom": 14,
+      "filter": ["==", ["get", "type"], "platform"],
+      "layout": {"visibility": "visible"},
+      "paint": {"fill-color": "rgba(0, 0, 0, 0.5)"}
+    },
+    {
+      "id": "transport_turntable",
+      "type": "fill",
+      "source": "osm",
+      "source-layer": "transport_areas",
+      "minzoom": 14,
+      "filter": ["==", ["get", "type"], "turntable"],
+      "layout": {"visibility": "visible"},
+      "paint": {"fill-color": "rgba(193, 193, 193, 1)"}
+    },
+    {
+      "id": "transport_traverser",
+      "type": "fill",
+      "source": "osm",
+      "source-layer": "transport_areas",
+      "minzoom": 14,
+      "filter": ["==", ["get", "type"], "traverser"],
+      "layout": {"visibility": "visible"},
+      "paint": {"fill-color": "rgba(193, 193, 193, 1)"}
+    },
+    {
+      "id": "transport_freight_platform",
+      "type": "fill",
+      "source": "osm",
+      "source-layer": "transport_areas",
+      "minzoom": 14,
+      "filter": ["==", ["get", "type"], "loading_ramp"],
+      "layout": {"visibility": "visible"},
+      "paint": {"fill-color": "rgba(0, 0, 0, 0.5)"}
+    },
+    {
       "id": "aero_taxiway_lines",
       "type": "line",
       "source": "osm",


### PR DESCRIPTION
This adds platforms, traversers and turntables to the historical and railway style. 
Platforms are visible on almost every kind of map and the lack of turntables and traversers creates gaps inbetween rails.
I also changed the railroad landuse fill colour of the historical style to make buildings visible.

**Historical:**
[Current](https://www.openhistoricalmap.org/#map=18/49.004562/8.408318&layers=O&date=1909-09-18&daterange=1825-01-01,2025-12-31):
![grafik](https://github.com/user-attachments/assets/88721111-affd-4f4e-a008-fe5f894244c2)
Maputnik preview:
![grafik](https://github.com/user-attachments/assets/542b9fd1-663f-4796-8477-6056d500761a)
[Example](https://www.openhistoricalmap.org/#map=19/48.801050/9.787222&layers=O&date=1909-09-18&daterange=1825-01-01,2025-12-31) without landuse:
![grafik](https://github.com/user-attachments/assets/4d55b791-ac3b-4c0d-bed1-aebffece2139)
[Building](https://www.openhistoricalmap.org/way/201052192) on platform:
![grafik](https://github.com/user-attachments/assets/81037fb9-1ab1-4daa-bd3c-03cd71499153)

**Railway:**
Current:
![grafik](https://github.com/user-attachments/assets/28a4cec7-a59a-4f17-ae94-ac236f0bd419)
Maputnik preview:
![grafik](https://github.com/user-attachments/assets/b2a542f5-c833-4523-8462-ec696d180d53)