### PR TITLE
1103 pedestrian areas

### DIFF
--- a/historical/historical.json
+++ b/historical/historical.json
@@ -554,13 +554,16 @@
       "type": "fill",
       "source": "osm",
       "source-layer": "transport_areas",
+      "minzoom": 14,
+      "maxzoom": 24,
+      "layout": {"visibility": "visible"},
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["footway", "pedestrian"]]],
         ["==", ["get", "area"], "yes"]
       ],
       "paint": {
-        "fill-color": "rgba(234,234,234, 1)",
+        "fill-color": "rgba(255,255,255, 1)",
         "fill-outline-color": "rgba(230,230,230, 1)"
       }
     },

--- a/historical/historical.json
+++ b/historical/historical.json
@@ -550,24 +550,6 @@
       }
     },
     {
-      "id": "pedestrian_area",
-      "type": "fill",
-      "source": "osm",
-      "source-layer": "transport_areas",
-      "minzoom": 14,
-      "maxzoom": 24,
-      "layout": {"visibility": "visible"},
-      "filter": [
-        "all",
-        ["in", ["get", "type"], ["literal", ["footway", "pedestrian"]]],
-        ["==", ["get", "area"], "yes"]
-      ],
-      "paint": {
-        "fill-color": "rgba(255,255,255, 1)",
-        "fill-outline-color": "rgba(230,230,230, 1)"
-      }
-    },
-    {
       "id": "amenity_areas",
       "type": "fill",
       "source": "osm",
@@ -3632,6 +3614,23 @@
           18,
           12
         ]
+      }
+    },
+    {
+      "id": "pedestrian_area",
+      "type": "fill",
+      "source": "osm",
+      "source-layer": "transport_areas",
+      "minzoom": 14,
+      "maxzoom": 24,
+      "layout": {"visibility": "visible"},
+      "filter": [
+        "all",
+        ["in", ["get", "type"], ["literal", ["footway", "pedestrian"]]]
+      ],
+      "paint": {
+        "fill-color": "rgba(255,255,255, 1)",
+        "fill-outline-color": "rgba(230,230,230, 1)"
       }
     },
     {

--- a/historical/historical.json
+++ b/historical/historical.json
@@ -3276,10 +3276,10 @@
           "interpolate",
           ["exponential", 1.5],
           ["zoom"],
-          13,
-          4,
-          18,
-          17
+          14,
+          2,
+          24,
+          6
         ]
       }
     },
@@ -3644,12 +3644,12 @@
         "line-color": "#ffffff",
         "line-width": [
           "interpolate",
-          ["exponential", 1.5],
+          ["exponential", 2],
           ["zoom"],
-          12,
-          2,
+          14,
+          1.5,
           18,
-          12
+          14
         ]
       }
     },

--- a/historical/historical.json
+++ b/historical/historical.json
@@ -2,7 +2,6 @@
   "version": 8,
   "name": "ohm-historical",
   "metadata": {"maputnik:renderer": "mbgljs"},
-  "attribution": "<a href=\"https://www.openhistoricalmap.org/\">OpenHistoricalMap</a>",
   "sources": {
     "osm": {
       "type": "vector",
@@ -547,6 +546,23 @@
       "paint": {
         "fill-color": "rgba(238, 236, 230, 1)",
         "fill-outline-color": "rgba(226, 223, 215, 1)"
+      }
+    },
+    {
+      "id": "pedestrian_area",
+      "type": "fill",
+      "source": "osm",
+      "source-layer": "transport_areas",
+      "minzoom": 14,
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        ["in", ["get", "type"], ["literal", ["footway", "pedestrian"]]]
+      ],
+      "layout": {"visibility": "visible"},
+      "paint": {
+        "fill-color": "rgba(246, 246, 246, 1)",
+        "fill-outline-color": "rgba(230,230,230, 1)"
       }
     },
     {
@@ -3614,23 +3630,6 @@
           18,
           12
         ]
-      }
-    },
-    {
-      "id": "pedestrian_area",
-      "type": "fill",
-      "source": "osm",
-      "source-layer": "transport_areas",
-      "minzoom": 14,
-      "maxzoom": 24,
-      "layout": {"visibility": "visible"},
-      "filter": [
-        "all",
-        ["in", ["get", "type"], ["literal", ["footway", "pedestrian"]]]
-      ],
-      "paint": {
-        "fill-color": "rgba(255,255,255, 1)",
-        "fill-outline-color": "rgba(230,230,230, 1)"
       }
     },
     {
@@ -6883,5 +6882,6 @@
       }
     }
   ],
+  "attribution": "<a href=\"https://www.openhistoricalmap.org/\">OpenHistoricalMap</a>",
   "id": "ab271ed3-6fe4-403a-b5ae-07113f8c57ab"
 }


### PR DESCRIPTION
Implements fixes identified in Issue [#1103: Styling for highway=pedestrian on closed ways and on multipolygon relations needs work](https://github.com/OpenHistoricalMap/issues/issues/1103).

