### PR TITLE
1157 nature reserve label sizing

### DIFF
--- a/historical/historical.json
+++ b/historical/historical.json
@@ -296,8 +296,6 @@
             "rgba(208, 220, 174, 1)",
             "pitch",
             "rgba(69, 150, 7, 0.39)",
-            "nature_reserve",
-            "rgba(212, 225, 211, 0.3)",
             "golf_course",
             "rgba(236, 240, 198, 1)",
             "transparent"

--- a/historical/historical.json
+++ b/historical/historical.json
@@ -5821,9 +5821,36 @@
       "type": "symbol",
       "source": "osm",
       "source-layer": "landuse_points_centroids",
+      "minzoom": 12,
+      "maxzoom": 16,
+      "filter": [
+        "all",
+        ["in", ["get", "type"], ["literal", ["nature_reserve"]]],
+        ["<", ["get", "area_m2"], 1000000000]
+      ],
+      "layout": {
+        "text-size": 14,
+        "text-field": ["get", "name"],
+        "text-font": ["OpenHistorical"]
+      },
+      "paint": {
+        "text-color": "rgba(95, 107, 71, 1)",
+        "text-halo-color": "rgba(201, 213, 190, 1)",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "landuse_areaslabels_nature_reserve_xl",
+      "type": "symbol",
+      "source": "osm",
+      "source-layer": "landuse_points_centroids",
       "minzoom": 6,
       "maxzoom": 12,
-      "filter": ["in", ["get", "type"], ["literal", ["nature_reserve"]]],
+      "filter": [
+        "all",
+        ["in", ["get", "type"], ["literal", ["nature_reserve"]]],
+        [">=", ["get", "area_m2"], 1000000000]
+      ],
       "layout": {
         "text-size": 24,
         "text-field": ["get", "name"],


### PR DESCRIPTION
attempts to resolve [nature_reserve labels need to account for area (size) of nature reserve #1157](https://github.com/OpenHistoricalMap/issues/issues/1157) by trying out some nature reserve label tuning based on `area_m2` in the centroid layer.

The testing of this feature is somewhat limited by [Ensure large area centroids are available in vtiles at appropriate zoom levels for labeling those large areas #1158](https://github.com/OpenHistoricalMap/issues/issues/1158), but that should not hold up deployment of this style.