### PR TITLE
Improving entertainment area labels based on area

### DIFF
--- a/historical/historical.json
+++ b/historical/historical.json
@@ -5926,7 +5926,7 @@
       "type": "symbol",
       "source": "osm",
       "source-layer": "landuse_points_centroids",
-      "minzoom": 6,
+      "minzoom": 7,
       "maxzoom": 12,
       "filter": [
         "all",
@@ -5934,7 +5934,7 @@
         [">=", ["get", "area_m2"], 100000000]
       ],
       "layout": {
-        "text-size": 24,
+        "text-size": [["interpolate", "linear"], ["zoom"], 7, 12, 8, 16, 9, 24, 12, 16],
         "text-field": ["get", "name"],
         "text-font": ["OpenHistorical"]
       },

--- a/historical/historical.json
+++ b/historical/historical.json
@@ -5765,7 +5765,7 @@
       }
     },
     {
-      "id": "landuse_areas_labels_park",
+      "id": "landuse_areas_labels_park_small",
       "type": "symbol",
       "source": "osm",
       "source-layer": "landuse_points_centroids",
@@ -5793,7 +5793,7 @@
             ]
           ]
         ],
-        [">", ["get", "area"], 12000]
+        ["<", ["get", "area_m2"], 40000]
       ],
       "layout": {
         "text-field": ["get", "name"],
@@ -5808,6 +5808,93 @@
         "text-color": "rgba(85, 104, 42, 1)",
         "text-halo-color": "rgba(228, 235, 209, 1)",
         "text-halo-width": 1,
+        "icon-translate-anchor": "map"
+      }
+    },
+    {
+      "id": "landuse_areas_labels_park_medium",
+      "type": "symbol",
+      "source": "osm",
+      "source-layer": "landuse_points_centroids",
+      "minzoom": 15,
+      "maxzoom": 20,
+      "filter": [
+        "all",
+        [
+          "in",
+          ["get", "type"],
+          [
+            "literal",
+            [
+              "park",
+              "camp_site",
+              "recreation_ground",
+              "sports_centre",
+              "stadium",
+              "village_green"
+            ]
+          ]
+        ],
+        [">=", ["get", "area_m2"], 40000],
+        ["<", ["get", "area_m2"], 3000000]
+      ],
+      "layout": {
+        "text-field": ["get", "name"],
+        "text-size": ["interpolate", ["linear"], ["zoom"], 12, 14, 13, 20, 16, 16],
+        "visibility": "visible",
+        "icon-text-fit": "none",
+        "text-allow-overlap": false,
+        "text-ignore-placement": false,
+        "text-font": ["OpenHistorical"]
+      },
+      "paint": {
+        "text-color": "rgba(64, 64, 64, 1)",
+        "text-halo-color": "rgba(228, 235, 209, 1)",
+        "text-opacity": ["interpolate", ["linear"], ["zoom"], 14.99, 0, 15, 1, 17, 1, 19, 0.1],
+        "text-halo-width": 2,
+        "icon-translate-anchor": "map"
+      }
+    },
+    {
+      "id": "landuse_areas_labels_park_large",
+      "type": "symbol",
+      "source": "osm",
+      "source-layer": "landuse_points_centroids",
+      "minzoom": 12,
+      "maxzoom": 15,
+      "filter": [
+        "all",
+        [
+          "in",
+          ["get", "type"],
+          [
+            "literal",
+            [
+              "park",
+              "camp_site",
+              "recreation_ground",
+              "sports_centre",
+              "stadium",
+              "village_green"
+            ]
+          ]
+        ],
+        [">=", ["get", "area_m2"], 3000000]
+      ],
+      "layout": {
+        "text-field": ["get", "name"],
+        "text-size": ["interpolate", ["linear"], ["zoom"], 12, 12, 13, 18, 16, 16],
+        "visibility": "visible",
+        "icon-text-fit": "none",
+        "text-allow-overlap": false,
+        "text-ignore-placement": false,
+        "text-font": ["OpenHistorical"]
+      },
+      "paint": {
+        "text-color": "rgba(85, 104, 42, 1)",
+        "text-halo-color": "rgba(228, 235, 209, 1)",
+        "text-opacity": ["interpolate", ["linear"], ["zoom"], 13.99, 1, 15, 0],
+        "text-halo-width": 2,
         "icon-translate-anchor": "map"
       }
     },
@@ -5934,7 +6021,7 @@
         [">=", ["get", "area_m2"], 100000000]
       ],
       "layout": {
-        "text-size": [["interpolate", "linear"], ["zoom"], 7, 12, 8, 16, 9, 24, 12, 16],
+        "text-size": ["interpolate", ["linear"], ["zoom"], 7, 12, 8, 16, 9, 24, 12, 14],
         "text-field": ["get", "name"],
         "text-font": ["OpenHistorical"]
       },

--- a/historical/historical.json
+++ b/historical/historical.json
@@ -5765,6 +5765,22 @@
       }
     },
     {
+      "id": "points_from_landuse_areas",
+      "type": "symbol",
+      "source": "osm",
+      "source-layer": "landuse_points_centroids",
+      "minzoom": 16,
+      "filter": [
+        "!",
+        ["in", ["get", "type"], ["literal", ["garden", "peak", "wetland"]]]
+      ],
+      "layout": {
+        "icon-image": "{type}-18",
+        "text-font": ["OpenHistorical"],
+        "visibility": "visible"
+      }
+    },
+    {
       "id": "landuse_areas_labels_park_small",
       "type": "symbol",
       "source": "osm",
@@ -5840,7 +5856,7 @@
       ],
       "layout": {
         "text-field": ["get", "name"],
-        "text-size": ["interpolate", ["linear"], ["zoom"], 12, 14, 13, 20, 16, 16],
+        "text-size": ["interpolate", ["linear"], ["zoom"], 12, 12, 13, 14, 16, 16],
         "visibility": "visible",
         "icon-text-fit": "none",
         "text-allow-overlap": false,
@@ -6675,58 +6691,6 @@
         "text-halo-color": "rgba(255, 255, 255, 1)",
         "text-halo-width": 0.5,
         "text-opacity": 1
-      }
-    },
-    {
-      "id": "points_from_landuse",
-      "type": "symbol",
-      "source": "osm",
-      "source-layer": "landuse_points_centroids",
-      "minzoom": 16,
-       "filter": [
-        "!",
-        ["in", ["get", "type"], ["literal", ["nature_reserve", "forest", "wood", "coastline"]]]
-      ],     
-      "layout": {
-        "icon-image": "{type}-18",
-        "text-font": ["OpenHistorical"],
-        "text-field": ["get", "name"],
-        "text-size": [
-          "interpolate",
-          ["linear"],
-          ["zoom"],
-          6,
-          8,
-          16,
-          10,
-          20,
-          12
-        ],
-        "text-anchor": "top",
-        "text-offset": [0, 1],
-        "visibility": "visible",
-        "icon-size": ["interpolate", ["linear"], ["zoom"], 15, 0.7, 20, 1.4]
-      },
-      "paint": {
-        "text-color": "rgba(80, 80, 80, 1)",
-        "text-halo-color": "rgba(255, 255, 255, 1)",
-        "text-halo-width": 0.5
-      }
-    },
-    {
-      "id": "points_from_landuse_areas",
-      "type": "symbol",
-      "source": "osm",
-      "source-layer": "landuse_points_centroids",
-      "minzoom": 16,
-      "filter": [
-        "!",
-        ["in", ["get", "type"], ["literal", ["garden", "peak", "wetland"]]]
-      ],
-      "layout": {
-        "icon-image": "{type}-18",
-        "text-font": ["OpenHistorical"],
-        "visibility": "visible"
       }
     },
     {

--- a/historical/historical.json
+++ b/historical/historical.json
@@ -6158,7 +6158,7 @@
         "icon-image": "{tourism}-18",
         "visibility": "visible",
         "text-field": ["get", "name"],
-        "text-size": ["interpolate", ["linear"], ["zoom"], 16, 10, 20, 12],
+        "text-size": ["interpolate", ["linear"], ["zoom"], 16, 12, 17, 14, 20, 16],
         "text-anchor": "center",
         "text-offset": [0, 0],
         "text-font": ["OpenHistorical"],
@@ -6524,13 +6524,13 @@
       }
     },
     {
-      "id": "transport_points_centroids",
+      "id": "transport_points_labels",
       "type": "symbol",
       "source": "osm",
       "source-layer": "transport_points_centroids",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": ["!=", ["get", "type"], "traffic_signals"],
+      "filter": ["!", ["in", ["get", "type"], ["literal", ["traffic_signals", "pedestrian"]]]],
       "layout": {
         "icon-image": "{type}-18",
         "visibility": "visible",
@@ -6551,7 +6551,7 @@
       }
     },
     {
-      "id": "transport_points_centroids_traffic_signals",
+      "id": "transport_points_labels_traffic_signals",
       "type": "symbol",
       "source": "osm",
       "source-layer": "transport_points_centroids",
@@ -6576,7 +6576,32 @@
       }
     },
     {
-      "id": "points_airport",
+      "id": "transport_points_labels_pedestrian",
+      "type": "symbol",
+      "source": "osm",
+      "source-layer": "transport_points_centroids",
+      "minzoom": 17,
+      "maxzoom": 24,
+      "filter": ["==", ["get", "type"], "pedestrian"],
+      "layout": {
+        "icon-image": "{type}-18",
+        "visibility": "visible",
+        "text-field": ["get", "name"],
+        "text-size": ["interpolate", ["linear"], ["zoom"], 10, 14, 18, 14],
+        "text-anchor": "top",
+        "text-offset": [0, 0.75],
+        "text-font": ["OpenHistorical"]
+      },
+      "paint": {
+        "icon-color": "#000000",
+        "text-color": "rgba(80, 80, 80, 1)",
+        "text-halo-color": "rgba(255, 255, 255, 1)",
+        "text-halo-width": 0.5,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "transport_points_labels_airports",
       "type": "symbol",
       "source": "osm",
       "source-layer": "transport_points_centroids",
@@ -6589,7 +6614,7 @@
         "text-font": ["OpenHistorical"]}
     },
     {
-      "id": "med_transport_points_centroids",
+      "id": "transport_points_labels_medium",
       "type": "symbol",
       "source": "osm",
       "source-layer": "transport_points_centroids",
@@ -6613,7 +6638,7 @@
       }
     },
     {
-      "id": "large_transport_points_centroids",
+      "id": "transport_area_labels_large",
       "type": "symbol",
       "source": "osm",
       "source-layer": "transport_points_centroids",
@@ -6637,7 +6662,7 @@
       }
     },
     {
-      "id": "points_placeofworshipother",
+      "id": "points_place_of_worship_other",
       "type": "symbol",
       "source": "osm",
       "source-layer": "buildings_points_centroids",

--- a/historical/historical.json
+++ b/historical/historical.json
@@ -283,7 +283,7 @@
       }
     },
     {
-      "id": "landuse_areas_z12-24_underlying_land_designation",
+      "id": "landuse_areas_underlying_land_designation",
       "type": "fill",
       "source": "osm",
       "source-layer": "landuse_areas",
@@ -550,7 +550,7 @@
       }
     },
     {
-      "id": "landuse_areas_z12_developed_open_space_smaller",
+      "id": "landuse_areas_developed_open_space_smaller",
       "type": "fill",
       "source": "osm",
       "source-layer": "landuse_areas",
@@ -6345,7 +6345,7 @@
       "type": "symbol",
       "source": "osm",
       "source-layer": "amenity_points_centroids",
-      "minzoom": 15,
+      "minzoom": 16,
       "maxzoom": 24,
       "layout": {
         "text-line-height": 1.2,

--- a/historical/historical.json
+++ b/historical/historical.json
@@ -5329,7 +5329,7 @@
       }
     },
     {
-      "id": "city_county_lines_admin7_8",
+      "id": "city_county_lines_admin_7-8",
       "type": "line",
       "source": "osm",
       "source-layer": "land_ohm_lines",
@@ -5348,7 +5348,7 @@
       }
     },
     {
-      "id": "admin_admin5_6",
+      "id": "admin_admin_5-6",
       "type": "line",
       "source": "osm",
       "source-layer": "land_ohm_lines",
@@ -5375,7 +5375,7 @@
       }
     },
     {
-      "id": "state_lines_admin4-case",
+      "id": "state_lines_admin_4-case",
       "type": "line",
       "source": "osm",
       "source-layer": "land_ohm_lines",
@@ -5405,7 +5405,7 @@
       }
     },
     {
-      "id": "state_lines_admin4",
+      "id": "state_lines_admin_4",
       "type": "line",
       "source": "osm",
       "source-layer": "land_ohm_lines",
@@ -5463,7 +5463,7 @@
       }
     },
     {
-      "id": "admin_countrylines_z10_case",
+      "id": "admin_country_lines_z10_case",
       "type": "line",
       "source": "osm",
       "source-layer": "land_ohm_lines",
@@ -5491,7 +5491,7 @@
       }
     },
     {
-      "id": "admin_countrylines_z10",
+      "id": "admin_country_lines_z10",
       "type": "line",
       "source": "osm",
       "source-layer": "land_ohm_lines",
@@ -5537,7 +5537,7 @@
       }
     },
     {
-      "id": "roadlabels_z14",
+      "id": "road_labels_z14",
       "type": "symbol",
       "source": "osm",
       "source-layer": "transport_lines",
@@ -5562,7 +5562,7 @@
       }
     },
     {
-      "id": "roadlabels_z11",
+      "id": "road_labels_z11",
       "type": "symbol",
       "source": "osm",
       "source-layer": "transport_lines",
@@ -6148,7 +6148,7 @@
       }
     },
     {
-      "id": "points_of_interest_frombuildings",
+      "id": "points_of_interest_from_buildings",
       "type": "symbol",
       "source": "osm",
       "source-layer": "buildings_points_centroids",
@@ -6173,7 +6173,7 @@
       }
     },
     {
-      "id": "points_of_interest_fromareasz14_centroids",
+      "id": "points_of_interest_from_areas_z14_centroids",
       "type": "symbol",
       "source": "osm",
       "source-layer": "amenity_points_centroids",
@@ -6217,7 +6217,7 @@
       }
     },
     {
-      "id": "points_of_interest_fromareasz14",
+      "id": "points_of_interest_from_areas_z14",
       "type": "symbol",
       "source": "osm",
       "source-layer": "amenity_points_centroids",
@@ -6261,7 +6261,7 @@
       }
     },
     {
-      "id": "points_of_interest_fromareas",
+      "id": "points_of_interest_from_areas",
       "type": "symbol",
       "source": "osm",
       "source-layer": "amenity_points_centroids",
@@ -6718,7 +6718,7 @@
       }
     },
     {
-      "id": "county_labels_z11_admin7_8_centroids",
+      "id": "county_labels_z11_admin_7-8_centroids",
       "type": "symbol",
       "source": "osm",
       "source-layer": "land_ohm_centroids",
@@ -6752,7 +6752,7 @@
       }
     },
     {
-      "id": "county_labels_z11_admin6_centroids",
+      "id": "county_labels_z11_admin_6_centroids",
       "type": "symbol",
       "source": "osm",
       "source-layer": "land_ohm_centroids",

--- a/historical/historical.json
+++ b/historical/historical.json
@@ -220,7 +220,7 @@
       }
     },
     {
-      "id": "landuse_areas_allz_6-12",
+      "id": "landuse_areas_all_z6-12",
       "type": "fill",
       "source": "osm",
       "source-layer": "landuse_areas",
@@ -365,11 +365,11 @@
       }
     },
     {
-      "id": "landuse_areas_z12_landcover_short",
+      "id": "landuse_areas_landcover_short",
       "type": "fill",
       "source": "osm",
       "source-layer": "landuse_areas",
-      "minzoom": 10,
+      "minzoom": 6,
       "maxzoom": 24,
       "filter": [
         "in",
@@ -498,11 +498,11 @@
       }
     },
     {
-      "id": "landuse_areas_z12_developed_open_space_larger",
+      "id": "landuse_areas_developed_open_space_larger",
       "type": "fill",
       "source": "osm",
       "source-layer": "landuse_areas",
-      "minzoom": 12,
+      "minzoom": 6,
       "maxzoom": 24,
       "layout": {"visibility": "visible"},
       "filter": [
@@ -5877,7 +5877,7 @@
       "source": "osm",
       "source-layer": "landuse_points_centroids",
       "minzoom": 12,
-      "maxzoom": 15,
+      "maxzoom": 16,
       "filter": [
         "all",
         [
@@ -5899,7 +5899,7 @@
       ],
       "layout": {
         "text-field": ["get", "name"],
-        "text-size": ["interpolate", ["linear"], ["zoom"], 12, 12, 13, 18, 16, 16],
+        "text-size": ["interpolate", ["linear"], ["zoom"], 12, 12, 16, 24],
         "visibility": "visible",
         "icon-text-fit": "none",
         "text-allow-overlap": false,
@@ -5909,7 +5909,7 @@
       "paint": {
         "text-color": "rgba(85, 104, 42, 1)",
         "text-halo-color": "rgba(228, 235, 209, 1)",
-        "text-opacity": ["interpolate", ["linear"], ["zoom"], 13.99, 1, 15, 0],
+        "text-opacity": ["interpolate", ["linear"], ["zoom"], 15.5, 1, 15.99, 0],
         "text-halo-width": 2,
         "icon-translate-anchor": "map"
       }
@@ -6148,7 +6148,7 @@
       }
     },
     {
-      "id": "points_of_interest_from_buildings",
+      "id": "points_of_interest_buildings",
       "type": "symbol",
       "source": "osm",
       "source-layer": "buildings_points_centroids",
@@ -6375,30 +6375,6 @@
         "text-translate-anchor": "viewport",
         "icon-translate-anchor": "viewport",
         "text-opacity": ["interpolate", ["linear"], ["zoom"], 16.99, 0, 17, 1]
-      }
-    },
-    {
-      "id": "points_of_interest_amenity_14",
-      "type": "symbol",
-      "source": "osm",
-      "source-layer": "amenity_points_centroids",
-      "minzoom": 14,
-      "maxzoom": 16,
-      "filter": ["all"],
-      "layout": {
-        "icon-image": "{type}-18",
-        "visibility": "visible",
-        "text-field": ["get", "name"],
-        "text-size": 8,
-        "text-anchor": "top",
-        "text-offset": [0, 1],
-        "text-font": ["OpenHistorical"]
-      },
-      "paint": {
-        "text-color": "rgba(80, 80, 80, 1)",
-        "text-halo-color": "rgba(255, 255, 255, 1)",
-        "text-halo-width": 0.5,
-        "text-halo-blur": 1
       }
     },
     {

--- a/historical/historical.json
+++ b/historical/historical.json
@@ -5785,7 +5785,7 @@
       "type": "symbol",
       "source": "osm",
       "source-layer": "landuse_points_centroids",
-      "minzoom": 14,
+      "minzoom": 16,
       "maxzoom": 24,
       "filter": [
         "all",
@@ -6297,43 +6297,6 @@
       }
     },
     {
-      "id": "points_of_interest_amenity_centroids",
-      "type": "symbol",
-      "source": "osm",
-      "source-layer": "amenity_points_centroids",
-      "minzoom": 15,
-      "maxzoom": 24,
-      "filter": ["all"],
-      "layout": {
-        "text-line-height": 1.2,
-        "text-size": [
-          "interpolate",
-          ["linear"],
-          ["zoom"],
-          15.99,
-          0,
-          16,
-          10,
-          20,
-          12
-        ],
-        "icon-image": "{type}-18",
-        "text-font": ["OpenHistorical"],
-        "visibility": "visible",
-        "text-offset": [0, 1],
-        "icon-size": ["interpolate", ["linear"], ["zoom"], 15, 0.7, 20, 1.4],
-        "text-anchor": "top",
-        "text-field": ["get", "name"]
-      },
-      "paint": {
-        "text-color": "rgba(80, 80, 80, 1)",
-        "text-halo-color": "rgba(255, 255, 255, 1)",
-        "text-halo-width": 0.5,
-        "text-halo-blur": 1,
-        "text-opacity": ["interpolate", ["linear"], ["zoom"], 16.9, 0, 17, 1]
-      }
-    },
-    {
       "id": "points_of_interest_other",
       "type": "symbol",
       "source": "osm",
@@ -6506,7 +6469,34 @@
       "source-layer": "transport_points_centroids",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": ["!", ["in", ["get", "type"], ["literal", ["traffic_signals", "pedestrian"]]]],
+      "filter": ["!", ["in", ["get", "type"], ["literal", ["traffic_signals", "pedestrian", "raceway"]]]],
+      "layout": {
+        "icon-image": "{type}-18",
+        "visibility": "visible",
+        "text-field": ["get", "name"],
+        "text-size": ["interpolate", ["linear"], ["zoom"], 10, 14, 18, 14],
+        "text-anchor": "top",
+        "text-offset": [0, 0.75],
+        "text-font": ["OpenHistorical"],
+        "icon-size": ["interpolate", ["linear"], ["zoom"], 10, 0.4, 20, 1.4]
+      },
+      "paint": {
+        "icon-color": "#000000",
+        "text-color": "rgba(80, 80, 80, 1)",
+        "text-halo-color": "rgba(255, 255, 255, 1)",
+        "text-halo-width": 0.5,
+        "text-halo-blur": 1,
+        "text-opacity": ["interpolate", ["linear"], ["zoom"], 12.99, 0, 13, 1]
+      }
+    },
+    {
+      "id": "transport_points_raceway",
+      "type": "symbol",
+      "source": "osm",
+      "source-layer": "transport_points_centroids",
+      "minzoom": 15,
+      "maxzoom": 24,
+      "filter": ["!", ["in", ["get", "type"], ["literal", ["traffic_signals", "pedestrian", "raceway"]]]],
       "layout": {
         "icon-image": "{type}-18",
         "visibility": "visible",


### PR DESCRIPTION
Addresses issues identified in [#1143: Ensure athletic, leisure, and entertainment area labels show up at appropriate zoom levels](https://github.com/OpenHistoricalMap/issues/issues/1143), along with some other naming convention tuneups