### PR TITLE
removed offending "to-string"s with s:\["to-string", (.+?)\],  && r:$1,

### DIFF
--- a/japanese_scroll/japanese_scroll.json
+++ b/japanese_scroll/japanese_scroll.json
@@ -2077,7 +2077,7 @@
         ["!=", ["get", "capital"], "yes"]
       ],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["BernerBasisschrift"],
         "text-transform": "uppercase",
         "text-size": ["interpolate", ["linear"], ["zoom"], 6, 13, 10, 15],
@@ -2117,7 +2117,7 @@
         ["==", ["get", "capital"], "yes"]
       ],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["BernerBasisschrift"],
         "text-transform": "uppercase",
         "text-size": ["interpolate", ["linear"], ["zoom"], 6, 16, 10, 20],
@@ -2159,7 +2159,7 @@
       ],
       "layout": {
         "visibility": "visible",
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["BernerBasisschrift"],
         "text-size": ["interpolate", ["linear"], ["zoom"], 6, 15, 10, 18],
         "text-line-height": 0.8,
@@ -2187,7 +2187,7 @@
       "filter": ["in", ["get", "type"], ["literal", ["state", "territory"]]],
       "layout": {
         "visibility": "visible",
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["BernerBasisschrift"],
         "text-size": ["interpolate", ["linear"], ["zoom"], 6, 15, 10, 18],
         "text-line-height": 0.8,
@@ -2219,7 +2219,7 @@
       ],
       "layout": {
         "visibility": "visible",
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-size": ["interpolate", ["linear"], ["zoom"], 4, 16, 6, 15],
         "text-font": ["BernerBasisschrift"],
         "symbol-placement": "point",
@@ -2249,7 +2249,7 @@
       "filter": ["==", ["get", "type"], "country"],
       "layout": {
         "visibility": "visible",
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-size": ["interpolate", ["linear"], ["zoom"], 4, 16, 6, 15],
         "text-font": ["BernerBasisschrift"],
         "symbol-placement": "point",

--- a/railway/railway.json
+++ b/railway/railway.json
@@ -5566,7 +5566,7 @@
       "minzoom": 14,
       "filter": ["all"],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "symbol-placement": "line",
         "symbol-spacing": 250,
         "symbol-avoid-edges": false,
@@ -5592,7 +5592,7 @@
       "minzoom": 11,
       "filter": ["in", ["get", "type"], ["literal", ["motorway", "trunk"]]],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "symbol-placement": "line",
         "symbol-spacing": 250,
         "symbol-avoid-edges": false,
@@ -5618,7 +5618,7 @@
       "minzoom": 6,
       "filter": ["==", ["get", "class"], "railway"],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "symbol-placement": "line",
         "symbol-spacing": 250,
         "symbol-avoid-edges": false,
@@ -5646,7 +5646,7 @@
       "maxzoom": 24,
       "filter": [">", ["get", "area"], 100000],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["OpenHistorical Italic"],
         "text-padding": 2,
         "text-allow-overlap": false,
@@ -5667,7 +5667,7 @@
       "maxzoom": 15,
       "filter": [">", ["get", "area"], 1000000],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["OpenHistorical Italic"],
         "text-padding": 2,
         "text-allow-overlap": false,
@@ -5689,7 +5689,7 @@
       "maxzoom": 24,
       "filter": ["in", ["get", "type"], ["literal", ["ocean", "sea"]]],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["OpenHistorical Italic"],
         "text-padding": 2,
         "text-allow-overlap": false,
@@ -5721,7 +5721,7 @@
       "maxzoom": 12,
       "filter": [">", ["get", "area"], 10000000],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["OpenHistorical Italic"],
         "text-padding": 2,
         "text-allow-overlap": false,
@@ -5750,7 +5750,7 @@
       "source-layer": "water_lines",
       "filter": ["in", ["get", "type"], ["literal", ["cliff"]]],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["OpenHistorical Italic"],
         "symbol-placement": "line",
         "symbol-spacing": 500,
@@ -5773,7 +5773,7 @@
       "source-layer": "water_lines",
       "filter": ["in", ["get", "type"], ["literal", ["dam"]]],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["OpenHistorical Italic"],
         "symbol-placement": "line",
         "symbol-spacing": 500,
@@ -5798,7 +5798,7 @@
       "maxzoom": 24,
       "filter": ["!", ["in", ["get", "type"], ["literal", ["cliff", "dam"]]]],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["OpenHistorical Italic"],
         "symbol-placement": "line",
         "symbol-spacing": 500,
@@ -5847,7 +5847,7 @@
         [">", ["get", "area"], 12000]
       ],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-size": ["interpolate", ["linear"], ["zoom"], 14, 11, 20, 14],
         "visibility": "none",
         "icon-text-fit": "none",
@@ -5886,7 +5886,7 @@
         ]
       ],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-size": 11,
         "text-font": ["OpenHistorical"],
         "visibility": "none"
@@ -5910,7 +5910,7 @@
         ["literal", ["forest", "nature_reserve", "wood"]]
       ],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-size": 11,
         "text-font": ["OpenHistorical"],
         "visibility": "none"
@@ -5934,7 +5934,7 @@
         ["literal", ["", "college", "education", "school", "university"]]
       ],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-size": 11,
         "text-font": ["OpenHistorical"]
       },
@@ -5956,7 +5956,7 @@
       ],
       "layout": {
         "visibility": "visible",
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-size": 9,
         "text-anchor": "center",
         "text-offset": [0, 0],
@@ -5979,7 +5979,7 @@
       "layout": {
         "icon-image": ["concat", ["get", "tourism"], "-18"],
         "visibility": "visible",
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-size": ["interpolate", ["linear"], ["zoom"], 16, 10, 20, 12],
         "text-anchor": "center",
         "text-offset": [0, 0],
@@ -6024,7 +6024,7 @@
       "layout": {
         "icon-image": ["concat", ["get", "type"], "-12"],
         "visibility": "visible",
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-size": 8,
         "text-anchor": "top",
         "text-offset": [0, 1],
@@ -6049,7 +6049,7 @@
       "layout": {
         "icon-image": ["concat", ["get", "type"], "-18"],
         "visibility": "visible",
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-size": [
           "interpolate",
           ["linear"],
@@ -6085,7 +6085,7 @@
       "layout": {
         "icon-image": ["concat", ["get", "type"], "-18"],
         "visibility": "visible",
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-size": 8,
         "text-anchor": "top",
         "text-offset": [0, 1],
@@ -6110,7 +6110,7 @@
       "layout": {
         "icon-image": ["concat", ["get", "type"], "-18"],
         "visibility": "visible",
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-size": [
           "interpolate",
           ["linear"],
@@ -6147,7 +6147,7 @@
       "layout": {
         "icon-image": ["concat", ["get", "type"], "-18"],
         "visibility": "visible",
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-size": [
           "interpolate",
           ["linear"],
@@ -6191,7 +6191,7 @@
       "layout": {
         "icon-image": ["concat", ["get", "site_type"], "-18"],
         "visibility": "visible",
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-size": [
           "interpolate",
           ["linear"],
@@ -6227,7 +6227,7 @@
       "layout": {
         "icon-image": ["concat", ["get", "artwork_type"], "-18"],
         "visibility": "visible",
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-size": [
           "interpolate",
           ["linear"],
@@ -6291,7 +6291,7 @@
       "layout": {
         "icon-image": "railstation-18",
         "visibility": "visible",
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-size": [
           "interpolate",
           ["linear"],
@@ -6332,7 +6332,7 @@
       "layout": {
         "icon-image": ["concat", ["get", "type"], "-18"],
         "visibility": "visible",
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-size": [
           "interpolate",
           ["linear"],
@@ -6403,7 +6403,7 @@
       "layout": {
         "icon-image": ["concat", ["get", "type"], "-12"],
         "text-font": ["OpenHistorical"],
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-size": 8,
         "text-anchor": "top",
         "text-offset": [0, 0.8]
@@ -6424,7 +6424,7 @@
       "layout": {
         "icon-image": ["concat", ["get", "type"], "-18"],
         "text-font": ["OpenHistorical"],
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-size": [
           "interpolate",
           ["linear"],
@@ -6474,7 +6474,7 @@
       "layout": {
         "icon-image": ["concat", ["get", "shop"], "-18"],
         "visibility": "visible",
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-size": 8,
         "text-anchor": "top",
         "text-offset": [0, 1],
@@ -6500,7 +6500,7 @@
         ["==", ["get", "admin_level"], 6]
       ],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["OpenHistorical"],
         "text-size": [
           "interpolate",
@@ -6534,7 +6534,7 @@
       "maxzoom": 20,
       "filter": ["in", ["get", "type"], ["literal", ["county"]]],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["OpenHistorical"],
         "text-size": [
           "interpolate",
@@ -6575,7 +6575,7 @@
         ]
       ],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["OpenHistorical"],
         "text-size": [
           "interpolate",
@@ -6606,7 +6606,7 @@
       "maxzoom": 20,
       "filter": ["in", ["get", "type"], ["literal", ["town"]]],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["OpenHistorical"],
         "text-size": [
           "interpolate",
@@ -6637,7 +6637,7 @@
       "maxzoom": 20,
       "filter": ["in", ["get", "type"], ["literal", ["city"]]],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["OpenHistorical"],
         "text-size": [
           "interpolate",
@@ -6672,7 +6672,7 @@
         ["==", ["get", "capital"], "yes"]
       ],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["OpenHistorical"],
         "text-size": ["interpolate", ["linear"], ["zoom"], 6, 12, 10, 15],
         "visibility": "visible",
@@ -6702,7 +6702,7 @@
         ["!=", ["get", "capital"], "yes"]
       ],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["OpenHistorical"],
         "text-size": ["interpolate", ["linear"], ["zoom"], 6, 12, 10, 15],
         "visibility": "visible",
@@ -6733,7 +6733,7 @@
       ],
       "layout": {
         "visibility": "visible",
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["OpenHistorical"],
         "text-size": ["interpolate", ["linear"], ["zoom"], 3, 9, 6, 15, 10, 18],
         "text-line-height": 1,
@@ -6761,7 +6761,7 @@
       "filter": ["in", ["get", "type"], ["literal", ["state", "territory"]]],
       "layout": {
         "visibility": "visible",
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["OpenHistorical"],
         "text-size": ["interpolate", ["linear"], ["zoom"], 3, 9, 6, 15, 10, 18],
         "text-line-height": 1,
@@ -6788,7 +6788,7 @@
       "maxzoom": 20,
       "filter": ["==", ["get", "featurecla"], "Admin-1 capital"],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["OpenHistorical Bold"],
         "text-size": 10,
         "text-transform": "uppercase",
@@ -6815,7 +6815,7 @@
       ],
       "layout": {
         "visibility": "visible",
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-size": [
           "interpolate",
           ["linear"],
@@ -6855,7 +6855,7 @@
       "filter": ["==", ["get", "type"], "country"],
       "layout": {
         "visibility": "visible",
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-size": [
           "interpolate",
           ["linear"],

--- a/woodblock/woodblock.json
+++ b/woodblock/woodblock.json
@@ -2169,7 +2169,7 @@
         ["!=", ["get", "capital"], "yes"]
       ],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["Eadui"],
         "text-size": ["interpolate", ["linear"], ["zoom"], 6, 13, 10, 15],
         "visibility": "visible",
@@ -2208,7 +2208,7 @@
         ["==", ["get", "capital"], "yes"]
       ],
       "layout": {
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["Eadui"],
         "text-size": ["interpolate", ["linear"], ["zoom"], 6, 16, 10, 20],
         "visibility": "visible",
@@ -2248,7 +2248,7 @@
       ],
       "layout": {
         "visibility": "visible",
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["Eadui"],
         "text-size": ["interpolate", ["linear"], ["zoom"], 6, 15, 10, 18],
         "text-line-height": 1,
@@ -2275,7 +2275,7 @@
       "filter": ["in", ["get", "type"], ["literal", ["state", "territory"]]],
       "layout": {
         "visibility": "visible",
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-font": ["Eadui"],
         "text-size": ["interpolate", ["linear"], ["zoom"], 6, 15, 10, 18],
         "text-line-height": 1,
@@ -2306,7 +2306,7 @@
       ],
       "layout": {
         "visibility": "visible",
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-size": [
           "interpolate",
           ["linear"],
@@ -2346,7 +2346,7 @@
       "filter": ["==", ["get", "type"], "country"],
       "layout": {
         "visibility": "visible",
-        "text-field": ["to-string", ["get", "name"]],
+        "text-field": ["get", "name"],
         "text-size": [
           "interpolate",
           ["linear"],


### PR DESCRIPTION
Addressing part of the issues identified in [#1164](https://github.com/OpenHistoricalMap/issues/issues/1164)