### PR TITLE
remove highway areas from transport labels & make raceway rule specific; addresses #1174

### DIFF
--- a/historical/historical.json
+++ b/historical/historical.json
@@ -6469,7 +6469,10 @@
       "source-layer": "transport_points_centroids",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": ["!", ["in", ["get", "type"], ["literal", ["traffic_signals", "pedestrian", "raceway"]]]],
+      "filter": ["all",
+        ["!", ["in", ["get", "type"], ["literal", ["traffic_signals", "pedestrian", "raceway"]]]],
+        ["!", ["in", ["get", "class"], ["literal", ["highway"]]]]
+      ],
       "layout": {
         "icon-image": "{type}-18",
         "visibility": "visible",
@@ -6496,7 +6499,7 @@
       "source-layer": "transport_points_centroids",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["!", ["in", ["get", "type"], ["literal", ["traffic_signals", "pedestrian", "raceway"]]]],
+      "filter": ["in", ["get", "type"], ["literal", ["raceway"]]],
       "layout": {
         "icon-image": "{type}-18",
         "visibility": "visible",


### PR DESCRIPTION
Very small style changes related to Issue [1174](https://github.com/OpenHistoricalMap/issues/issues/1144)