### PR TITLE
Handle null tunnel/bridge values in style filters

### DIFF
--- a/historical/historical.json
+++ b/historical/historical.json
@@ -1918,9 +1918,9 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "construction"],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["==", ["get", "construction"], "tertiary"],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -1949,9 +1949,9 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "construction"],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["==", ["get", "construction"], "secondary"],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -1980,9 +1980,9 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "construction"],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["==", ["get", "construction"], "primary_link"],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -2011,10 +2011,10 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "construction"],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["!=", ["get", "ford"], "yes"],
         ["==", ["get", "construction"], "primary"],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -2044,13 +2044,13 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "construction"],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         [
           "in",
           ["get", "construction"],
           ["literal", ["motorway_link", "trunk_link"]]
         ],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -2080,9 +2080,9 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "construction"],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["in", ["get", "construction"], ["literal", ["motorway", "trunk"]]],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -2177,9 +2177,9 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "construction"],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["==", ["get", "construction"], "secondary_link"],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -2217,9 +2217,9 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "construction"],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["==", ["get", "construction"], "primary_link"],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -2250,13 +2250,13 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "construction"],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         [
           "in",
           ["get", "construction"],
           ["literal", ["motorway_link", "trunk_link"]]
         ],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -2287,9 +2287,9 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "construction"],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["==", ["get", "construction"], "tertiary"],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -2327,9 +2327,9 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "construction"],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["==", ["get", "construction"], "secondary"],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -2367,10 +2367,10 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "construction"],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["!=", ["get", "ford"], "yes"],
         ["==", ["get", "construction"], "primary"],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -2409,9 +2409,9 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "construction"],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["in", ["get", "construction"], ["literal", ["motorway", "trunk"]]],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3323,7 +3323,7 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["service"]]],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3353,7 +3353,7 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["residential", "unclassified"]]],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3405,8 +3405,8 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "tertiary_link"],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3440,8 +3440,8 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "tertiary"],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3474,8 +3474,8 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "secondary"],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3506,8 +3506,8 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "secondary_link"],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3538,8 +3538,8 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "primary_link"],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3568,9 +3568,9 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "primary"],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["!=", ["get", "ford"], "yes"],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3604,8 +3604,8 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["motorway_link", "trunk_link"]]],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3635,8 +3635,8 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["motorway", "trunk"]]],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3774,8 +3774,8 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "secondary_link"],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3804,8 +3804,8 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "tertiary_link"],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3844,8 +3844,8 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "primary_link"],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3875,8 +3875,8 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["motorway_link", "trunk_link"]]],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3916,8 +3916,8 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "tertiary"],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3956,8 +3956,8 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "secondary"],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3986,9 +3986,9 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "primary"],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["!=", ["get", "ford"], "yes"],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -4028,8 +4028,8 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["motorway", "trunk"]]],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",

--- a/japanese_scroll/japanese_scroll.json
+++ b/japanese_scroll/japanese_scroll.json
@@ -1036,7 +1036,7 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "tertiary"],
-        ["!=", ["get", "tunnel"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "none",
@@ -1065,7 +1065,7 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "secondary"],
-        ["!=", ["get", "tunnel"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "none",
@@ -1094,7 +1094,7 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["primary_link"]]],
-        ["!=", ["get", "tunnel"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "none",
@@ -1123,7 +1123,7 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["primary"]]],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["!=", ["get", "ford"], "yes"]
       ],
       "layout": {
@@ -1162,7 +1162,7 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["motorway_link", "trunk_link"]]],
-        ["!=", ["get", "tunnel"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "none",
@@ -1200,7 +1200,7 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["motorway", "trunk"]]],
-        ["!=", ["get", "tunnel"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "none",
@@ -1421,7 +1421,7 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "secondary_link"],
-        ["!=", ["get", "tunnel"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -1457,7 +1457,7 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["primary_link"]]],
-        ["!=", ["get", "tunnel"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -1502,7 +1502,7 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["motorway_link", "trunk_link"]]],
-        ["!=", ["get", "tunnel"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -1584,7 +1584,7 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "tertiary"],
-        ["!=", ["get", "tunnel"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -1628,7 +1628,7 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "secondary"],
-        ["!=", ["get", "tunnel"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -1672,7 +1672,7 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["primary"]]],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["!=", ["get", "ford"], "yes"]
       ],
       "layout": {
@@ -1718,7 +1718,7 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["motorway", "trunk"]]],
-        ["!=", ["get", "tunnel"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",

--- a/railway/railway.json
+++ b/railway/railway.json
@@ -1685,9 +1685,9 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "construction"],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["==", ["get", "construction"], "tertiary"],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -1716,9 +1716,9 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "construction"],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["==", ["get", "construction"], "secondary"],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -1747,9 +1747,9 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["construction"]]],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["==", ["get", "construction"], "primary_link"],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -1778,10 +1778,10 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["construction"]]],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["!=", ["get", "ford"], "yes"],
         ["in", ["get", "construction"], ["literal", ["primary"]]],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -1811,13 +1811,13 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["construction"]]],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         [
           "in",
           ["get", "construction"],
           ["literal", ["motorway_link", "trunk_link"]]
         ],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -1847,9 +1847,9 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["construction"]]],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["in", ["get", "construction"], ["literal", ["motorway", "trunk"]]],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -1979,9 +1979,9 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "construction"],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["==", ["get", "construction"], "secondary_link"],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -2019,9 +2019,9 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["construction"]]],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["==", ["get", "construction"], "primary_link"],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -2052,13 +2052,13 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["construction"]]],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         [
           "in",
           ["get", "construction"],
           ["literal", ["motorway_link", "trunk_link"]]
         ],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -2089,9 +2089,9 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "construction"],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["==", ["get", "construction"], "tertiary"],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -2129,9 +2129,9 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "construction"],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["==", ["get", "construction"], "secondary"],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -2169,10 +2169,10 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["construction"]]],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["!=", ["get", "ford"], "yes"],
         ["==", ["get", "construction"], "primary"],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -2203,9 +2203,9 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["construction"]]],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["in", ["get", "construction"], ["literal", ["motorway", "trunk"]]],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -2674,7 +2674,7 @@
         "all",
         ["in", ["get", "type"], ["literal", ["light_rail"]]],
         ["==", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {"visibility": "visible"},
       "paint": {
@@ -2702,7 +2702,7 @@
         "all",
         ["in", ["get", "type"], ["literal", ["light_rail"]]],
         ["==", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {"visibility": "visible"},
       "paint": {
@@ -3270,7 +3270,7 @@
           ["get", "type"],
           ["literal", ["residential", "service", "unclassified"]]
         ],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3322,8 +3322,8 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "tertiary_link"],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3357,8 +3357,8 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "tertiary"],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3391,8 +3391,8 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "secondary"],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3423,8 +3423,8 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "secondary_link"],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3455,8 +3455,8 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["primary_link"]]],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3485,9 +3485,9 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["primary"]]],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["!=", ["get", "ford"], "yes"],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3521,8 +3521,8 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["motorway_link", "trunk_link"]]],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3552,8 +3552,8 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["motorway", "trunk"]]],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3665,8 +3665,8 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "secondary_link"],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3695,8 +3695,8 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["tertiary_link"]]],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3735,8 +3735,8 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["primary_link"]]],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3766,8 +3766,8 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["motorway_link", "trunk_link"]]],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3799,8 +3799,8 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "tertiary"],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3839,8 +3839,8 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "secondary"],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3869,9 +3869,9 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["primary"]]],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["!=", ["get", "ford"], "yes"],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -3903,8 +3903,8 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["motorway", "trunk"]]],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -4030,7 +4030,7 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["subway"]]],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["==", ["get", "bridge"], 1]
       ],
       "layout": {"visibility": "visible"},
@@ -4049,7 +4049,7 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["light_rail"]]],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["==", ["get", "bridge"], 1]
       ],
       "layout": {"visibility": "visible"},
@@ -4068,7 +4068,7 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["light_rail"]]],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["==", ["get", "bridge"], 1]
       ],
       "layout": {"visibility": "visible"},
@@ -4415,7 +4415,7 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["subway"]]],
-        ["!=", ["get", "tunnel"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {"visibility": "none"},
       "paint": {
@@ -4449,8 +4449,8 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["light_rail"]]],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {"visibility": "visible"},
       "paint": {
@@ -4468,8 +4468,8 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["subway"]]],
-        ["!=", ["get", "tunnel"], 1],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {"visibility": "visible"},
       "paint": {
@@ -5124,9 +5124,9 @@
         ["!=", ["get", "usage"], "military"],
         ["!=", ["get", "usage"], "tourism"],
         ["!=", ["get", "service"], "spur"],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["!=", ["get", "service"], "siding"],
-        ["!=", ["get", "bridge"], 1]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -5158,7 +5158,7 @@
         ["!=", ["get", "usage"], "military"],
         ["!=", ["get", "usage"], "tourism"],
         ["!=", ["get", "service"], "spur"],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["!=", ["get", "service"], "siding"],
         ["==", ["get", "bridge"], 1]
       ],
@@ -5192,7 +5192,7 @@
         ["!=", ["get", "usage"], "tourism"],
         ["!=", ["get", "service"], "spur"],
         ["!=", ["get", "service"], "siding"],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["!=", ["get", "usage"], "military"]
       ],
       "layout": {

--- a/woodblock/woodblock.json
+++ b/woodblock/woodblock.json
@@ -1037,7 +1037,7 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "tertiary"],
-        ["!=", ["get", "tunnel"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "none",
@@ -1066,7 +1066,7 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "secondary"],
-        ["!=", ["get", "tunnel"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "none",
@@ -1095,7 +1095,7 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["primary_link"]]],
-        ["!=", ["get", "tunnel"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "none",
@@ -1124,7 +1124,7 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["primary"]]],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["!=", ["get", "ford"], "yes"]
       ],
       "layout": {
@@ -1163,7 +1163,7 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["motorway_link", "trunk_link"]]],
-        ["!=", ["get", "tunnel"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "none",
@@ -1201,7 +1201,7 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["motorway", "trunk"]]],
-        ["!=", ["get", "tunnel"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "none",
@@ -1422,7 +1422,7 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "secondary_link"],
-        ["!=", ["get", "tunnel"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -1458,7 +1458,7 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["primary_link"]]],
-        ["!=", ["get", "tunnel"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -1503,7 +1503,7 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["motorway_link", "trunk_link"]]],
-        ["!=", ["get", "tunnel"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -1585,7 +1585,7 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "tertiary"],
-        ["!=", ["get", "tunnel"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -1629,7 +1629,7 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "secondary"],
-        ["!=", ["get", "tunnel"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -1673,7 +1673,7 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["primary"]]],
-        ["!=", ["get", "tunnel"], 1],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["!=", ["get", "ford"], "yes"]
       ],
       "layout": {
@@ -1719,7 +1719,7 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["motorway", "trunk"]]],
-        ["!=", ["get", "tunnel"], 1]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",


### PR DESCRIPTION
From: https://github.com/OpenHistoricalMap/issues/issues/1321#issuecomment-4282776165

Follow-up to the tile-size optimization in ohm-deploy#746, where `NULLIF(tunnel, 0)` / `NULLIF(bridge, 0)` (and oneway/expressway) were added to drop `0` values from the tiles — since `boolint` always emits `0` for absent tags, that value ends up on almost every feature and adds unnecessary weight.


Once the tiles stopped including `tunnel: 0` / `bridge: 0`, the  features got excluded and most railways/roads disappeared except the explicit `tunnel=1` / `bridge=1` ones. as currently shows in staging: 

https://www.ohmstaging.org/#map=12/46.4343/6.8692&layers=O&date=2025-12-31&daterange=0049-10-17,2025-12-31

<img width="476" height="379" alt="image" src="https://github.com/user-attachments/assets/cc92413c-db6d-4a19-817f-e00925fc8a9f" />



Fix: wrap the `get` in `coalesce` so missing properties default to `0`:


So the solution is  update the line `["!=", ["get", "tunnel"], 1]` to  `["!=", ["coalesce", ["get", "tunnel"], 0], 1]` 



cc. @erictheise 