### PR TITLE
Fix/null safe rail tunnel bridge

### DIFF
--- a/historical/historical.json
+++ b/historical/historical.json
@@ -5,7 +5,7 @@
   "sources": {
     "ohm": {
       "type": "vector",
-      "tiles": ["https://vtiles.openhistoricalmap.org/maps/ohm/{z}/{x}/{y}.pbf"]
+      "tiles": ["https://vtiles.ohmstaging.org/maps/ohm/{z}/{x}/{y}.pbf"]
     },
     "ohm_landcover_hillshade": {
       "type": "raster",
@@ -18,12 +18,12 @@
     },
     "ne": {
       "type": "vector",
-      "tiles": ["https://vtiles.openhistoricalmap.org/maps/ne/{z}/{x}/{y}.pbf"]
+      "tiles": ["https://vtiles.ohmstaging.org/maps/ne/{z}/{x}/{y}.pbf"]
     },
     "osm_land": {
       "type": "vector",
       "tiles": [
-        "https://vtiles.openhistoricalmap.org/maps/osm_land/{z}/{x}/{y}.pbf"
+        "https://vtiles.ohmstaging.org/maps/osm_land/{z}/{x}/{y}.pbf"
       ],
       "minzoom": 0,
       "maxzoom": 22,
@@ -1852,7 +1852,7 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "construction"],
-        ["==", ["get", "bridge"], 0],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1],
         ["==", ["get", "construction"], "road"]
       ],
       "layout": {
@@ -1883,7 +1883,7 @@
       "filter": [
         "all",
         ["==", ["get", "type"], "construction"],
-        ["==", ["get", "bridge"], 0],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1],
         [
           "in",
           ["get", "construction"],
@@ -4110,7 +4110,7 @@
         "all",
         ["in", ["get", "type"], ["literal", ["miniature", "narrow_gauge"]]],
         ["!", ["in", ["get", "service"], ["literal", ["siding", "yard"]]]],
-        ["==", ["get", "tunnel"], 0]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {"visibility": "visible"},
       "paint": {
@@ -4219,7 +4219,7 @@
           ["literal", ["abandoned", "dismantled", "disused", "razed"]]
         ],
         ["!", ["in", ["get", "service"], ["literal", ["siding", "yard"]]]],
-        ["==", ["get", "tunnel"], 0]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {"visibility": "visible"},
       "paint": {
@@ -4303,7 +4303,7 @@
         ],
         ["!", ["in", ["get", "service"], ["literal", ["siding", "yard"]]]],
         ["==", ["get", "usage"], "main"],
-        ["==", ["get", "tunnel"], 0]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -4436,7 +4436,7 @@
         ],
         ["!", ["in", ["get", "service"], ["literal", ["siding", "yard"]]]],
         ["!=", ["get", "usage"], "main"],
-        ["==", ["get", "tunnel"], 0]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -4472,7 +4472,7 @@
         ],
         ["!", ["in", ["get", "service"], ["literal", ["siding", "yard"]]]],
         ["==", ["get", "usage"], "main"],
-        ["==", ["get", "tunnel"], 0]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -4580,7 +4580,7 @@
         ],
         ["!", ["in", ["get", "service"], ["literal", ["siding", "yard"]]]],
         ["!=", ["get", "usage"], "main"],
-        ["==", ["get", "tunnel"], 0]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",

--- a/historical/historical.json
+++ b/historical/historical.json
@@ -5,7 +5,7 @@
   "sources": {
     "ohm": {
       "type": "vector",
-      "tiles": ["https://vtiles.ohmstaging.org/maps/ohm/{z}/{x}/{y}.pbf"]
+      "tiles": ["https://vtiles.openhistoricalmap.org/maps/ohm/{z}/{x}/{y}.pbf"]
     },
     "ohm_landcover_hillshade": {
       "type": "raster",
@@ -18,12 +18,12 @@
     },
     "ne": {
       "type": "vector",
-      "tiles": ["https://vtiles.ohmstaging.org/maps/ne/{z}/{x}/{y}.pbf"]
+      "tiles": ["https://vtiles.openhistoricalmap.org/maps/ne/{z}/{x}/{y}.pbf"]
     },
     "osm_land": {
       "type": "vector",
       "tiles": [
-        "https://vtiles.ohmstaging.org/maps/osm_land/{z}/{x}/{y}.pbf"
+        "https://vtiles.openhistoricalmap.org/maps/osm_land/{z}/{x}/{y}.pbf"
       ],
       "minzoom": 0,
       "maxzoom": 22,

--- a/japanese_scroll/japanese_scroll.json
+++ b/japanese_scroll/japanese_scroll.json
@@ -1006,7 +1006,7 @@
           ["get", "type"],
           ["literal", ["residential", "service", "unclassified"]]
         ],
-        ["==", ["get", "bridge"], 0]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "none",

--- a/railway/railway.json
+++ b/railway/railway.json
@@ -1619,7 +1619,7 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["construction"]]],
-        ["==", ["get", "bridge"], 0],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1],
         ["in", ["get", "construction"], ["literal", ["road"]]]
       ],
       "layout": {
@@ -1650,7 +1650,7 @@
       "filter": [
         "all",
         ["in", ["get", "type"], ["literal", ["construction"]]],
-        ["==", ["get", "bridge"], 0],
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1],
         [
           "in",
           ["get", "construction"],
@@ -4593,7 +4593,7 @@
           ["in", ["get", "service"], ["literal", ["siding", "spur", "yard"]]]
         ],
         ["in", ["get", "type"], ["literal", ["preserved", "rail"]]],
-        ["==", ["get", "tunnel"], 0]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -4615,7 +4615,7 @@
       "filter": [
         "all",
         ["==", ["get", "usage"], "main"],
-        ["==", ["get", "tunnel"], 0],
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1],
         ["in", ["get", "type"], ["literal", ["preserved", "rail"]]],
         [
           "!",
@@ -4755,7 +4755,7 @@
         ],
         ["!", ["in", ["get", "service"], ["literal", ["siding", "yard"]]]],
         ["==", ["get", "service"], "spur"],
-        ["==", ["get", "tunnel"], 0]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -4797,7 +4797,7 @@
           ["in", ["get", "service"], ["literal", ["siding", "spur", "yard"]]]
         ],
         ["==", ["get", "usage"], "tourism"],
-        ["==", ["get", "tunnel"], 0]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -4834,7 +4834,7 @@
           ["in", ["get", "service"], ["literal", ["siding", "spur", "yard"]]]
         ],
         ["==", ["get", "usage"], "tourism"],
-        ["==", ["get", "tunnel"], 0]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -4880,7 +4880,7 @@
           ["in", ["get", "service"], ["literal", ["siding", "spur", "yard"]]]
         ],
         ["==", ["get", "usage"], "military"],
-        ["==", ["get", "tunnel"], 0]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -4917,7 +4917,7 @@
           ["in", ["get", "service"], ["literal", ["siding", "spur", "yard"]]]
         ],
         ["==", ["get", "usage"], "military"],
-        ["==", ["get", "tunnel"], 0]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -4963,7 +4963,7 @@
           ["in", ["get", "service"], ["literal", ["siding", "spur", "yard"]]]
         ],
         ["==", ["get", "usage"], "branch"],
-        ["==", ["get", "tunnel"], 0]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -4990,7 +4990,7 @@
           ["in", ["get", "service"], ["literal", ["siding", "spur", "yard"]]]
         ],
         ["==", ["get", "usage"], "branch"],
-        ["==", ["get", "tunnel"], 0]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -5036,7 +5036,7 @@
           ["in", ["get", "service"], ["literal", ["siding", "spur", "yard"]]]
         ],
         ["==", ["get", "usage"], "industrial"],
-        ["==", ["get", "tunnel"], 0]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",
@@ -5073,7 +5073,7 @@
           ["in", ["get", "service"], ["literal", ["siding", "spur", "yard"]]]
         ],
         ["==", ["get", "usage"], "industrial"],
-        ["==", ["get", "tunnel"], 0]
+        ["!=", ["coalesce", ["get", "tunnel"], 0], 1]
       ],
       "layout": {
         "visibility": "visible",

--- a/woodblock/woodblock.json
+++ b/woodblock/woodblock.json
@@ -1007,7 +1007,7 @@
           ["get", "type"],
           ["literal", ["residential", "service", "unclassified"]]
         ],
-        ["==", ["get", "bridge"], 0]
+        ["!=", ["coalesce", ["get", "bridge"], 0], 1]
       ],
       "layout": {
         "visibility": "none",


### PR DESCRIPTION
The PR #59 fixed filters using the pattern `["!=", ["get", "tunnel"], 1]` → `["!=", ["coalesce", ["get", "tunnel"], 0], 1]`, but missed the inverse pattern `["==", ["get", "tunnel"], 0]` (and the equivalent for `bridge`), which is used by rail layers and a couple of construction layers.

Since vector tiles omit the `tunnel`/`bridge` property when its value is `0`, the strict equality `== 0` evaluates to `false` against `null` and the layers stop rendering. As a result, only bridge rails were visible on the map.

