### PR TITLE
Add GitHub Action to publish map-styles to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,6 @@ on:
           - minor
           - major
         default: patch
-      dry_run:
-        description: 'Dry run (no push, no publish to npm)'
-        type: boolean
-        default: false
 
 concurrency:
   group: release
@@ -22,21 +18,22 @@ concurrency:
 
 jobs:
   release:
+    if: github.ref_name == 'staging'
     runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write
     steps:
-      - name: Verify branch (real releases only from staging)
-        if: inputs.dry_run == false
+      - name: Verify staging branch
         run: |
           if [ "${{ github.ref_name }}" != "staging" ]; then
-            echo "::error::Real releases can only run from 'staging' (got: ${{ github.ref_name }}). Enable 'dry_run' to test from another branch."
+            echo "::error::Releases can only be triggered from the 'staging' branch (got: ${{ github.ref_name }})"
             exit 1
           fi
 
       - uses: actions/checkout@v4
         with:
+          ref: staging
           fetch-depth: 0
 
       - uses: actions/setup-node@v4
@@ -59,21 +56,9 @@ jobs:
           git add package.json package-lock.json dist/
           git commit -m "Packaging ${NEW_VERSION} with rebuilt /dist"
           git tag "v${NEW_VERSION}"
-          echo "NEW_VERSION=${NEW_VERSION}" >> "$GITHUB_ENV"
 
       - name: Push to GitHub
-        if: inputs.dry_run == false
-        run: git push origin ${{ github.ref_name }} --follow-tags
-
-      - name: Publish to npm (dry run)
-        if: inputs.dry_run == true
-        run: npm publish --provenance --access public --dry-run
+        run: git push origin staging --follow-tags
 
       - name: Publish to npm with provenance
-        if: inputs.dry_run == false
         run: npm publish --provenance --access public
-
-      - name: Dry run summary
-        if: inputs.dry_run == true
-        run: |
-          echo "::notice::Dry run complete. Would publish v${NEW_VERSION}. No commits or tags pushed; nothing uploaded to npm."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ on:
           - minor
           - major
         default: patch
+      dry_run:
+        description: 'Dry run (no push, no publish to npm)'
+        type: boolean
+        default: false
 
 concurrency:
   group: release
@@ -18,22 +22,21 @@ concurrency:
 
 jobs:
   release:
-    if: github.ref_name == 'staging'
     runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write
     steps:
-      - name: Verify staging branch
+      - name: Verify branch (real releases only from staging)
+        if: inputs.dry_run == false
         run: |
           if [ "${{ github.ref_name }}" != "staging" ]; then
-            echo "::error::Releases can only be triggered from the 'staging' branch (got: ${{ github.ref_name }})"
+            echo "::error::Real releases can only run from 'staging' (got: ${{ github.ref_name }}). Enable 'dry_run' to test from another branch."
             exit 1
           fi
 
       - uses: actions/checkout@v4
         with:
-          ref: staging
           fetch-depth: 0
 
       - uses: actions/setup-node@v4
@@ -56,9 +59,21 @@ jobs:
           git add package.json package-lock.json dist/
           git commit -m "Packaging ${NEW_VERSION} with rebuilt /dist"
           git tag "v${NEW_VERSION}"
+          echo "NEW_VERSION=${NEW_VERSION}" >> "$GITHUB_ENV"
 
       - name: Push to GitHub
-        run: git push origin staging --follow-tags
+        if: inputs.dry_run == false
+        run: git push origin ${{ github.ref_name }} --follow-tags
+
+      - name: Publish to npm (dry run)
+        if: inputs.dry_run == true
+        run: npm publish --provenance --access public --dry-run
 
       - name: Publish to npm with provenance
+        if: inputs.dry_run == false
         run: npm publish --provenance --access public
+
+      - name: Dry run summary
+        if: inputs.dry_run == true
+        run: |
+          echo "::notice::Dry run complete. Would publish v${NEW_VERSION}. No commits or tags pushed; nothing uploaded to npm."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release to npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    if: github.ref_name == 'staging'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Verify staging branch
+        run: |
+          if [ "${{ github.ref_name }}" != "staging" ]; then
+            echo "::error::Releases can only be triggered from the 'staging' branch (got: ${{ github.ref_name }})"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          ref: staging
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version, rebuild /dist, commit and tag
+        run: |
+          NEW_VERSION=$(npm version ${{ inputs.bump }} --no-git-tag-version)
+          NEW_VERSION="${NEW_VERSION#v}"
+          npm run build
+          git add package.json package-lock.json dist/
+          git commit -m "Packaging ${NEW_VERSION} with rebuilt /dist"
+          git tag "v${NEW_VERSION}"
+
+      - name: Push to GitHub
+        run: git push origin staging --follow-tags
+
+      - name: Publish to npm with provenance
+        run: npm publish --provenance --access public

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -21,5 +24,5 @@ jobs:
       - name: Build /dist
         run: npm run build
 
-      - name: Validate npm package (dry-run)
-        run: npm publish --dry-run
+      - name: Validate npm package (dry-run with OIDC)
+        run: npm publish --provenance --access public --dry-run

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,26 @@
+name: Validate build
+
+on:
+  push:
+    branches-ignore:
+      - staging
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+
+      - name: Build /dist
+        run: npm run build
+
+      - name: Validate npm package (dry-run)
+        run: npm publish --dry-run

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches-ignore:
       - staging
-  pull_request:
 
 jobs:
   validate:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,9 +8,6 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -24,5 +21,5 @@ jobs:
       - name: Build /dist
         run: npm run build
 
-      - name: Validate npm package (dry-run with OIDC)
-        run: npm publish --provenance --access public --dry-run
+      - name: Validate npm package (dry-run)
+        run: npm publish --dry-run

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Miscellaneous notes:
 
 ## Versioning and publishing to npm
 
+> Releases can be automated via [Actions → "Release to npm"](https://github.com/OpenHistoricalMap/map-styles/actions/workflows/release.yml) — click **Run workflow**, choose `patch` / `minor` / `major`, and it builds `/dist`, commits, tags, and publishes with provenance via npm Trusted Publishers (no token required). Manual steps below remain as a fallback.
+
 1. increment the version in `package.json`, e.g., `0.9.7`
 1. commit your style changes, including `/dist/*` & `package.json`, push to GitHub, and [create a corresponding release](https://github.com/OpenHistoricalMap/map-styles/releases/new), e.g., `v0.9.7`
 1. publish to npm using `npm publish`


### PR DESCRIPTION
Currently it's hard to push the map-styles module, so I added a workflow to release new versions from the Actions tab instead of doing it manually.

It bumps the version, rebuilds /dist, pushes the tag, and publishes to npm. Uses Trusted Publishers so no token is needed.
Only runs from `staging`. To release: Actions → "Release to npm" → Run workflow → pick patch/minor/major.


cc. @jeffreyameyer 