### PR TITLE
Move cliff from water_lines to natural_lines

### DIFF
--- a/historical/historical.json
+++ b/historical/historical.json
@@ -912,7 +912,7 @@
       "id": "water_lines_cliff_line",
       "type": "line",
       "source": "ohm",
-      "source-layer": "water_lines",
+      "source-layer": "natural_lines",
       "minzoom": 15,
       "maxzoom": 24,
       "filter": [
@@ -935,7 +935,7 @@
       "id": "water_lines_cliff_line_triangles",
       "type": "line",
       "source": "ohm",
-      "source-layer": "water_lines",
+      "source-layer": "natural_lines",
       "minzoom": 15,
       "maxzoom": 24,
       "filter": [
@@ -960,7 +960,7 @@
       "id": "water_lines_waterfall_triangle",
       "type": "line",
       "source": "ohm",
-      "source-layer": "water_lines",
+      "source-layer": "natural_lines",
       "minzoom": 15,
       "maxzoom": 24,
       "filter": [
@@ -5665,7 +5665,7 @@
       "id": "water_lines_labels_cliff",
       "type": "symbol",
       "source": "ohm",
-      "source-layer": "water_lines",
+      "source-layer": "natural_lines",
       "filter": ["==", ["get", "type"], "cliff"],
       "layout": {
         "text-size": ["interpolate", ["linear"], ["zoom"], 11, 9, 13, 11],

--- a/railway/railway.json
+++ b/railway/railway.json
@@ -719,7 +719,7 @@
       "id": "water_lines_cliff_line",
       "type": "line",
       "source": "ohm",
-      "source-layer": "water_lines",
+      "source-layer": "natural_lines",
       "minzoom": 15,
       "maxzoom": 24,
       "filter": [
@@ -742,7 +742,7 @@
       "id": "water_lines_cliff_line_triangles",
       "type": "line",
       "source": "ohm",
-      "source-layer": "water_lines",
+      "source-layer": "natural_lines",
       "minzoom": 15,
       "maxzoom": 24,
       "filter": [
@@ -767,7 +767,7 @@
       "id": "water_lines_waterfall_triangle",
       "type": "line",
       "source": "ohm",
-      "source-layer": "water_lines",
+      "source-layer": "natural_lines",
       "minzoom": 15,
       "maxzoom": 24,
       "filter": [
@@ -5752,7 +5752,7 @@
       "id": "water_lineslabels-cliff",
       "type": "symbol",
       "source": "ohm",
-      "source-layer": "water_lines",
+      "source-layer": "natural_lines",
       "filter": ["in", ["get", "type"], ["literal", ["cliff"]]],
       "layout": {
         "text-field": ["get", "name"],


### PR DESCRIPTION
Cliffs aren't only found on coasts, so they don't belong in water_lines. This moves the cliff layers (line, triangle, and label) to natural_lines instead, in both the historical and railway styles

Addresses https://github.com/OpenHistoricalMap/issues/issues/1345
