### PR TITLE
Limit Christian cross to Christian cemeteries

### DIFF
--- a/dist/historical/historical.json
+++ b/dist/historical/historical.json
@@ -914,12 +914,41 @@
       "minzoom": 11,
       "maxzoom": 24,
       "filter": [
-        "==",
+        "all",
         [
-          "get",
-          "type"
+          "==",
+          [
+            "get",
+            "type"
+          ],
+          "cemetery"
         ],
-        "cemetery"
+        [
+          "==",
+          [
+            "get",
+            "religion"
+          ],
+          "christian"
+        ],
+        [
+          "!",
+          [
+            "in",
+            [
+              "get",
+              "denomination"
+            ],
+            [
+              "literal",
+              [
+                "jehovahs_witness",
+                "mormon",
+                "iglesia_ni_cristo"
+              ]
+            ]
+          ]
+        ]
       ],
       "layout": {
         "visibility": "visible"

--- a/dist/ohm.styles.js
+++ b/dist/ohm.styles.js
@@ -917,12 +917,41 @@ ohmVectorStyles = {
         "minzoom": 11,
         "maxzoom": 24,
         "filter": [
-          "==",
+          "all",
           [
-            "get",
-            "type"
+            "==",
+            [
+              "get",
+              "type"
+            ],
+            "cemetery"
           ],
-          "cemetery"
+          [
+            "==",
+            [
+              "get",
+              "religion"
+            ],
+            "christian"
+          ],
+          [
+            "!",
+            [
+              "in",
+              [
+                "get",
+                "denomination"
+              ],
+              [
+                "literal",
+                [
+                  "jehovahs_witness",
+                  "mormon",
+                  "iglesia_ni_cristo"
+                ]
+              ]
+            ]
+          ]
         ],
         "layout": {
           "visibility": "visible"

--- a/historical/historical.json
+++ b/historical/historical.json
@@ -579,7 +579,19 @@
       "source-layer": "landuse_areas",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": ["==", ["get", "type"], "cemetery"],
+      "filter": [
+        "all",
+        ["==", ["get", "type"], "cemetery"],
+        ["==", ["get", "religion"], "christian"],
+        [
+          "!",
+          [
+            "in",
+            ["get", "denomination"],
+            ["literal", ["jehovahs_witness", "mormon", "iglesia_ni_cristo"]]
+          ]
+        ]
+      ],
       "layout": {"visibility": "visible"},
       "paint": {
         "fill-pattern": "cross_space_18px",


### PR DESCRIPTION
Limit the repeating Latin cross pattern to Christian cemeteries, except for cemeteries associated with certain Christian denominations that avoid the cross symbol.

[<img width="800" height="600" alt="The Latin cross pattern appears on one cemetery but not another." src="https://github.com/user-attachments/assets/7fa60250-98ba-4330-a0f2-fed64a0d3da7" />](https://localhost:8888/#13.16/39.25479/-84.3379)

[<img width="800" height="600" alt="The Latin cross pattern does not appear on a large cemetery outside of Salt Lake City." src="https://github.com/user-attachments/assets/b82f1015-2511-49b9-a984-266baeb48119" />](https://localhost:8888/#13.17/40.76918/-111.87684)

For now, I have the stylesheet looking for a `denomination` of `jehovahs_witness`, `mormon`, and `iglesia_ni_cristo`, based on current usage in the database. However, OSM is trending away from `mormon` in favor of `latter_day_saints`, and the OSM Wiki also mentions [`la_luz_del_mundo`](https://wiki.openstreetmap.org/wiki/Tag:denomination%3Dla_luz_del_mundo) as another denomination to special-case. We can add these and other special cases once they appear in the database.

Fixes OpenHistoricalMap/issues#1406.